### PR TITLE
fixed flutter v1.5.4 run error type 'List<dynamic>' is not a subtype …

### DIFF
--- a/lib/drawer.dart
+++ b/lib/drawer.dart
@@ -39,7 +39,7 @@ class NavigationDrawerState extends State<NavigationDrawerDemo> {
 
   @override
   Widget build(BuildContext context) {
-    var drawerOptions = [];
+    var drawerOptions = <Widget>[];
     for (var i = 0; i < drawerItems.length; i++) {
       var d = drawerItems[i];
       drawerOptions.add(new ListTile(


### PR DESCRIPTION
I fixed flutter v1.5.4 run error type 'List<dynamic>' is not a subtype of type 'List<Widget>'